### PR TITLE
[bugfix/pass-classname-to-field] - Add support to use className props in Fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formcat",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A simple and easy way to control forms in React using the React Context API",
   "main": "index.js",
   "scripts": {

--- a/src/fields/Wrapper.js
+++ b/src/fields/Wrapper.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Wrapper = ({ label, required, children, error, reverse }) => {
+const Wrapper = ({ label, required, children, error, reverse, className }) => {
   const clone = React.cloneElement(children, {
     ...(!!label && { id: label }),
-    className: error ? 'formcat-error' : ''
+    className: `${className} ${error ? 'formcat-error' : ''}`.trim()
   })
   return (
     <div>
@@ -23,11 +23,13 @@ Wrapper.propTypes = {
   children: PropTypes.node,
   label: PropTypes.string,
   reverse: PropTypes.bool,
-  error: PropTypes.bool
+  error: PropTypes.bool,
+  className: PropTypes.string
 }
 
 Wrapper.defaultProps = {
   label: '',
+  className: '',
   required: false,
   error: false,
   reverse: false

--- a/src/fields/test.js
+++ b/src/fields/test.js
@@ -66,6 +66,30 @@ describe('Fields', () => {
     ).toBeFalsy()
   })
 
+  it('Should pass className to input element when have a props', () => {
+    render(
+      <Form>
+        <InputField data-testid="field" name="first_name" className="custom-class" required />
+      </Form>
+    )
+
+    expect(screen.getByTestId(/field/).getAttribute('class')).toBe('custom-class')
+  })
+
+  it('Should pass className to input element with error when have a props', () => {
+    render(
+      <Form>
+        <InputField data-testid="field" name="first_name" className="custom-class" required />
+      </Form>
+    )
+
+    const field = screen.getByTestId(/field/)
+    fireEvent.change(field)
+    fireEvent.blur(field)
+
+    expect(field.getAttribute('class')).toBe('custom-class formcat-error')
+  })
+
   it('Should submit correctly', (done) => {
     const onSubmit = jest.fn()
     const { container } = render(


### PR DESCRIPTION
This PR resolve #9 issue allowing the use of className in fields